### PR TITLE
Fix: it does not work when after update cronjob.

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -602,7 +602,12 @@ func (jm *ControllerV2) syncCronJob(
 	case errors.IsAlreadyExists(err):
 		// If the job is created by other actor, assume  it has updated the cronjob status accordingly
 		klog.InfoS("Job already exists", "cronjob", klog.KRef(cronJob.GetNamespace(), cronJob.GetName()), "job", klog.KRef(jobReq.GetNamespace(), jobReq.GetName()))
-		return cronJob, nil, updateStatus, err
+		// When the job created by other actor and the status of cronjob has not been
+		// updated normally, so here need get all jobs again. 
+		jobResp ,err = jm.jobControl.GetJob(cronJob.GetNamespace(),jobReq.GetName())
+		if err != nil {
+			return cronJob, nil, updateStatus, err
+		}
 	case err != nil:
 		// default error handling
 		jm.recorder.Eventf(cronJob, corev1.EventTypeWarning, "FailedCreate", "Error creating job: %v", err)


### PR DESCRIPTION
when update cronjob after posting a job and before update the status, the cronjob status will update failed, but the job has been created, the next sync time, will create again and get a job without nothing, then the nil job will update into the cronjob status active list, like below:
		
		...
		status:
		 active:
		 - apiVersion: batch/v1
		   kind: Job
		lastScheduleTime: "2022-08-17T02:05:00Z"

like that, the cronjob will do not work any more.  so need get jobs again.


